### PR TITLE
Initialized the closeModal.js script which finds the button with the …

### DIFF
--- a/public/js/closeModal.js
+++ b/public/js/closeModal.js
@@ -1,0 +1,22 @@
+// Start of Code [Evan Towlerton]
+
+// Find the close button for the modal in the DOM with the class "close"
+const closeButton = document.querySelector('.close');
+
+// If the close button exists then run the toggleDrawer function
+if (closeButton) {
+    function toggleDrawer() {
+        // Finds the drawer element in the DOM and sets it to a variable
+        const drawer = document.querySelector('#modal');
+        // If the drawer element exists remove the class show
+        // By removing the show class this will close the modal 
+        if (drawer) {
+            drawer.classList.remove('show');
+        }
+    }
+}
+
+// Attach event listener to close button to run toggleDrawer function when clicked
+closeButton.addEventListener('click', toggleDrawer);
+
+// A script source tag will need to be implemented in the dashboard.handlebars 

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -74,5 +74,6 @@
 
 </section>
 
-
+<!-- Importing the closeModal Script [ET] -->
+<script src="/js/closeModal.js"></script>
 


### PR DESCRIPTION
…class close in the DOM. If that button exists then it will run the toggleDrawer function which finds the Modal in the DOM, if that Modal exists it will remove the class show. By removing this class this will essentially functioning as closing the modal. I also imported the closeModal script into the dashboard.handlebars view